### PR TITLE
Add HTTPS to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,9 +102,9 @@
       "env": {
         "NODE_ENV": "production",
         "NODE_PATH": "./src",
-        "HOST": "http://localhost",
-        "PORT": 80,
-        "SCRIPT_HOST": "http://localhost"
+        "HOST": "https://tournavation-db.cloudapp.net",
+        "PORT": 443,
+        "SCRIPT_HOST": "https://tournavation-db.cloudapp.net"
       }
     }
   }

--- a/src/config.js
+++ b/src/config.js
@@ -9,14 +9,18 @@ const environment = {
 
 const host = process.env.HOST || 'http://localhost';
 const port = process.env.PORT || 3000;
+const insecurePort = environment.isProduction ? 80 : 3000;
 
-const baseUrl = host + (port === '80' ? '' : ':' + port);
+const baseUrl = host + (port === '443' || port === '80' ? '' : ':' + port);
 const apiBaseUrl = baseUrl + '/api/';
 const scriptUrl = process.env.SCRIPT_HOST || 'http://localhost:8080';
 
 module.exports = Object.assign({
   host: host,
   port: port,
+  insecurePort: insecurePort,
+  sslKeyPath: process.env.SSL_KEY_PATH,
+  sslCertPath: process.env.SSL_CERT_PATH,
   baseUrl: baseUrl,
   apiBaseUrl: apiBaseUrl,
   scriptUrl: scriptUrl,

--- a/webpack.client-watch.js
+++ b/webpack.client-watch.js
@@ -4,18 +4,20 @@ var config = require("./webpack.client.js");
 var CommonsChunkPlugin = require("webpack/lib/optimize/CommonsChunkPlugin");
 
 var host = process.env.HOST || "localhost";
+var port = 8080;
 
 config.cache = true;
 config.debug = true;
 config.devtool = "eval";
 
 config.entry.main.unshift(
-	"webpack-dev-server/client?http://" + host + ":8080",
+	"webpack-dev-server/client?http://" + host + ":" + port,
 	"webpack/hot/only-dev-server"
 );
 
+var publicPath = "http://" + host + ":" + port + "/dist/";
 config.output.filename = "app-bundle.js"
-config.output.publicPath = "http://" + host + ":8080/dist/";
+config.output.publicPath = publicPath;
 config.output.hotUpdateMainFilename = "update/[hash]/update.json";
 config.output.hotUpdateChunkFilename = "update/[hash]/[id].update.js";
 
@@ -43,16 +45,19 @@ config.module.postLoaders =  [
 ];
 
 config.devServer = {
-	publicPath:  "http://" + host + ":8080/dist/",
+    https:       false,    
+    host:        host,
+    port:        port,
+	publicPath:  publicPath,
 	contentBase: path.join(__dirname, "static"),
 	hot:         true,
+    debug:       true,
 	inline:      true,
 	lazy:        false,
 	quiet:       true,
 	noInfo:      false,
 	headers:     {"Access-Control-Allow-Origin": "*"},
 	stats:       {colors: true},
-	host:        host
 };
 
 module.exports = config;

--- a/webpack.client.js
+++ b/webpack.client.js
@@ -60,9 +60,9 @@ module.exports = {
 		new webpack.DefinePlugin({
 			"process.env": {
 				NODE_ENV: '"production"',
-				//HOST: '"http://localhost"',
-				HOST: '"http://tournavation-db.cloudapp.net/"',
-				PORT: '"80"'
+				//HOST: '"https://localhost"',
+				HOST: '"https://tournavation-db.cloudapp.net/"',
+				PORT: '"443"'
 			}
 		}),
 		/*new ReactGlobalizePlugin({


### PR DESCRIPTION
When running in production, secure all requests using https.
Additionally start a redirect server on the default http port so
insecure requests are automatically sent to https
